### PR TITLE
getText(name).set doesn't exist

### DIFF
--- a/api/shared-types/y.text.md
+++ b/api/shared-types/y.text.md
@@ -15,11 +15,6 @@ const ydoc = new Y.Doc()
 
 // Method 1: Define a top-level type
 const ytext = ydoc.getText('my text type') 
-// Method 2: Define Y.Text that can be included into the Yjs document
-const ytextNested = new Y.Text()
-
-// Nested types can be included as content into any other shared type
-ytext.set('my nested text', ytextNested)
 
 // Common methods
 ytext.insert(0, 'abc') // insert three elements


### PR DESCRIPTION
I think this is wrong in the documentation, when trying the `set` method I get: `ydoc.getText(...).set is not a function`.

