### PR TITLE
Correct Documented Changes Event

### DIFF
--- a/getting-started/working-with-shared-types.md
+++ b/getting-started/working-with-shared-types.md
@@ -90,7 +90,7 @@ ymap.observe(event => {
 ydoc.transact(() => {
   ymap.set('food', 'pencake')
   ymap.set('number', 31)
-}) // => changes: Map({ number: { action: 'added' }, food: { action: 'updated', oldValue: undefined } })
+}) // => changes: Map({ number: { action: 'added' }, food: { action: 'updated', oldValue: 'pizza' } })
 ```
 
 Event handlers and observers are called after each transaction. If possible, you should bundle as many changes in a single transaction as possible. The advantage is that you reduce expensive observer calls and create fewer updates that are sent to other peers.


### PR DESCRIPTION
Hello, 

Great project by the way. I've been learning about CRDTs and Yjs for a couple of days now and the docs have been really helpful. 

I noticed that the documented resulting changes from the transaction in the example in this file might be wrong. In the `Y.Map`, we initially set the value of `food` to `pizza`. So when the transaction runs to update `food` to `pencake` and to add `number` to `31`, shouldn't the `oldValue` for `food` should be `pizza`?

If that's the case, I made the correction in this PR. If it's not the case, it would be great to learn about why and perhaps the docs can be updated to explain. 

Thank you