### PR TITLE
Fix argument type of YArray.insert()

### DIFF
--- a/api/delta-format.md
+++ b/api/delta-format.md
@@ -115,8 +115,8 @@ ydoc.transact(() => {
 }) // => [{ insert: [2, "abc", 3] }]
 
 ydoc.transact(() => {
-  yarray.insert(0, 'x')
-  yarray.insert(2, 'y')
+  yarray.insert(0, ['x'])
+  yarray.insert(2, ['y'])
 }) // => [{ insert: ['x'] }, { retain: 1 }, { insert: ['y'] }]
 ```
 


### PR DESCRIPTION
A tiny mistake was handled according to `YArray.insert()` declaration:
```typescript
export class YArray<T> extends AbstractType<YArrayEvent<T>> implements Iterable<T> {
    insert(index: number, content: Array<T>): void;
}
```