### PR TITLE
add y-webxdc as a connection provider

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -25,6 +25,7 @@
 * [Connection Provider](ecosystem/connection-provider/README.md)
   * [y-websocket](ecosystem/connection-provider/y-websocket.md)
   * [y-webrtc](ecosystem/connection-provider/y-webrtc.md)
+  * [y-webxdc](https://codeberg.org/webxdc/y-webxdc)
   * [y-dat](ecosystem/connection-provider/y-hyper.md)
   * [y-sweet](https://github.com/drifting-in-space/y-sweet)
   * [Liveblocks](https://liveblocks.io/yjs)


### PR DESCRIPTION
Hi!

This PR is intended to add a listing for the [webxdc provider](https://codeberg.org/webxdc/y-webxdc) to the [connection providers page](https://docs.yjs.dev/ecosystem/connection-provider).

I didn't see any contributing guidelines, so I just followed the example of #54. I hope it's satisfactory :)