### PR TITLE
Add SuperViz to the list of connection providers

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -29,6 +29,7 @@
   * [y-dat](ecosystem/connection-provider/y-hyper.md)
   * [y-sweet](https://github.com/drifting-in-space/y-sweet)
   * [Liveblocks](https://liveblocks.io/yjs)
+  * [SuperViz](https://docs.superviz.com/collaboration/integrations/YJS/overview)
 * [Database Provider](ecosystem/database-provider/README.md)
   * [y-indexeddb](ecosystem/database-provider/y-indexeddb.md)
   * [y-leveldb](ecosystem/database-provider/y-leveldb.md)


### PR DESCRIPTION
This pull request includes a small update to the `SUMMARY.md` file to add a new link under the ecosystem section.

* [`SUMMARY.md`](diffhunk://#diff-4f74b24c8cd7466c1c46dc972d8e284ed47091160afda95a432cc000f2eceb4aR32): Added a link to the SuperViz documentation under the ecosystem section.