### PR TITLE
Fix expected result in undo-manager.md

### DIFF
--- a/api/undo-manager.md
+++ b/api/undo-manager.md
@@ -87,7 +87,7 @@ doc.transact(() => {
   ytext.insert(0, 'abc')
 }, 41)
 undoManager.undo()
-ytext.toString() // => '' (not tracked because 41 is not an instance of
+ytext.toString() // => 'abc' (not tracked because 41 is not an instance of
                  //        `trackedOrigins`)
 ytext.delete(0, 3) // revert change
 


### PR DESCRIPTION
According to the context, since 41 is not in the `trackedOrigins`, the 'abc' is not undo-ed, so the expected result should be 'abc'