### PR TITLE
fix(y-websocket): update docs to reflect actual status states

### DIFF
--- a/ecosystem/connection-provider/y-websocket.md
+++ b/ecosystem/connection-provider/y-websocket.md
@@ -25,7 +25,7 @@ const doc = new Y.Doc()
 const wsProvider = new WebsocketProvider('ws://localhost:1234', 'my-roomname', doc)
 
 wsProvider.on('status', event => {
-  console.log(event.status) // logs "connected" or "disconnected"
+  console.log(event.status) // logs "connected", "disconnected" or "connecting
 })
 ```
 {% endtab %}


### PR DESCRIPTION
Hello! 

While I was debugging my application that uses `y-websocket`, I noticed that there was a `connecting` state which wasn't documented anywhere. This PR seeks to add the docs to it. Thanks!