### PR TITLE
Add ygo (Go port of Yjs) to Ports to other languages

### DIFF
--- a/ecosystem/ports-to-other-languages.md
+++ b/ecosystem/ports-to-other-languages.md
@@ -8,6 +8,10 @@ description: Yjs has been ported to other languages.
 C# port of Yjs
 {% endembed %}
 
+## ygo
+
+A pure Go port of Yjs. Wire-compatible with the JavaScript reference (V1/V2 update codecs, awareness, snapshot), with the full CRDT engine (YArray, YMap, YText with rich-text formatting and embeds, YXml\*), built-in WebSocket and HTTP sync transports, and an UndoManager. In production at Re:Earth.
+
 {% embed url="https://github.com/reearth/ygo" %}
 Go port of Yjs
 {% endembed %}

--- a/ecosystem/ports-to-other-languages.md
+++ b/ecosystem/ports-to-other-languages.md
@@ -8,6 +8,10 @@ description: Yjs has been ported to other languages.
 C# port of Yjs
 {% endembed %}
 
+{% embed url="https://github.com/reearth/ygo" %}
+Go port of Yjs
+{% endembed %}
+
 ### Work in progress
 
 {% embed url="https://github.com/yjs/yrs" %}


### PR DESCRIPTION
Adds a Go port of Yjs to the `Ports to other languages` page.

## About the port

- **Repository:** https://github.com/reearth/ygo
- **License:** MIT
- **Latest release:** [v1.19.0](https://github.com/reearth/ygo/releases/tag/v1.19.0)
- **Maintenance:** Active. In production at Re:Earth (Eukarya). Semver-stable v1.x public API.

## Scope

- **Full CRDT engine** — YArray, YMap, YText (with rich-text Format + InsertEmbed), YXml*. Arbitrarily nested types; recursive ToJSON unwrap.
- **Wire-format compatible with Yjs JS** — V1 and V2 update codecs, awareness, snapshot. Verified by a JS↔Go interop fixture suite that round-trips through \`node\` against the Yjs reference.
- **Cross-reference audit complete** — closed a 10-issue audit against Yjs JS and yrs across the v1.9.0–v1.15.0 cycle, covering YText format markers, observer event shapes (YArrayEvent.Delta, YMapEvent.Keys with action/oldValue, YTextEvent embeds), transaction-commit housekeeping (auto-GC, split re-merge), snapshot semantics, and YATA conflict-scan edges.
- **Sync transports** — WebSocket and HTTP. WebSocket server is a drop-in for Hocuspocus-aware clients at the protocol-extension (message types 4-10), lifecycle (OnLoadDocument / OnFirstPeer / OnLastPeer / OnUnloadDocument), and outbound-webhook layers (provider/webhook subpackage with HMAC signing + debounce + bounded retry).
- **Production hardening** — UndoManager, structured slog logging, ctx-aware methods, panic-safe transactions and hooks, DoS caps on awareness state and pending-items queue, semaphore-backed connection limits, \`crypto/rand\` ClientID.

## Changes

Single edit to \`ecosystem/ports-to-other-languages.md\`: one \`{% embed %}\` block following the existing format. No other files affected.