### PR TITLE
Add Velt to Connection Providers

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -31,6 +31,7 @@
   * [Liveblocks](https://liveblocks.io/yjs)
   * [SuperViz](https://docs.superviz.com/collaboration/integrations/YJS/overview)
   * [Hocuspocus](https://tiptap.dev/docs/hocuspocus/getting-started/overview)
+  * [Velt](https://velt.dev/libraries/yjs)
 * [Database Provider](ecosystem/database-provider/README.md)
   * [y-indexeddb](ecosystem/database-provider/y-indexeddb.md)
   * [y-leveldb](ecosystem/database-provider/y-leveldb.md)


### PR DESCRIPTION
Adds Velt to the Connection Provider list, matching the existing external entries (y-sweet, Liveblocks, SuperViz, Hocuspocus).

Velt is a managed Yjs backend — realtime WebSocket sync, persistent storage, offline support with automatic reconnection, and version history, with no server setup ([`@veltdev/crdt`](https://www.npmjs.com/package/@veltdev/crdt) on npm). It's already listed in the [yjs/yjs README](https://github.com/yjs/yjs#providers) under Providers as "Velt YJs" — this PR mirrors that entry onto the docs site.

Docs: https://docs.velt.dev/realtime-collaboration/crdt/overview
Live demo: https://velt-general-crdt-demo.vercel.app/